### PR TITLE
arm: 96b_carbon: only enable SPI by default if BLUETOOTH is required

### DIFF
--- a/boards/arm/96b_carbon/96b_carbon_defconfig
+++ b/boards/arm/96b_carbon/96b_carbon_defconfig
@@ -15,9 +15,6 @@ CONFIG_UART_CONSOLE_ON_DEV_NAME="UART_1"
 # enable pinmux
 CONFIG_PINMUX=y
 
-# enable SPI
-CONFIG_SPI=y
-
 # enable GPIO ports A, B, C, D
 CONFIG_GPIO=y
 CONFIG_GPIO_STM32_PORTD=y

--- a/boards/arm/96b_carbon/Kconfig.defconfig
+++ b/boards/arm/96b_carbon/Kconfig.defconfig
@@ -10,4 +10,11 @@ if BOARD_96B_CARBON
 config BOARD
 	default 96b_carbon
 
+if BLUETOOTH
+
+config SPI
+	default y
+
+endif # BLUETOOTH
+
 endif # BOARD_96B_CARBON


### PR DESCRIPTION
Bluetooth will always require SPI, but don't enable it by default unless
required by the user.

Change-Id: Ie0e394e32f12a41da39d3f2d55b26de22589afc5
Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>